### PR TITLE
Use Systemd Services for the Monitoring and Response Time Logging Infra

### DIFF
--- a/conf/roles/grafana/files/grafana-server.service
+++ b/conf/roles/grafana/files/grafana-server.service
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Grafana - The open platform for beautiful analytics and monitoring
+Documentation=https://grafana.com/
+After=network.target
+
+[Service]
+User=grafana
+WorkingDirectory=/opt/grafana
+ExecStart=/opt/grafana/bin/grafana-server
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/roles/grafana/tasks/main.yml
+++ b/conf/roles/grafana/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Create Grafana User
+  user:
+    name: grafana
+- name: Grafana
+  unarchive:
+    src: /opt/repo/grafana-4.4.1.linux-x64.tar.gz
+    dest: /opt/
+- name: Create Link
+  file:
+    src: /opt/grafana-4.4.1
+    dest: /opt/grafana
+    state: link
+- name: Set Owner and Permissions
+  file:
+    path: /opt/grafana-4.4.1
+    owner: grafana
+    group: grafana
+    recurse: yes
+    state: directory
+- name: Create Data Path
+  file:
+    path: /var/lib/grafana
+    owner: grafana
+    group: grafana
+    recurse: yes
+    state: directory
+- name: Create Log Path
+  file:
+    path: /var/log/grafana
+    owner: grafana
+    group: grafana
+    recurse: yes
+    state: directory
+- name: Create Plugin Path
+  file:
+    path: /var/lib/grafana/plugins
+    owner: grafana
+    group: grafana
+    state: directory
+- name: Create the service
+  copy:
+    src: ../files/grafana-server.service
+    dest: /usr/lib/systemd/system/grafana-server.service
+- name: Activate Service
+  systemd:
+    name: grafana-server
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/conf/roles/load/tasks/main.yml
+++ b/conf/roles/load/tasks/main.yml
@@ -7,8 +7,3 @@
   apt:
     name: maven
     state: latest
-#- name: Git
-#  git:
-#    repo: ssh://git@git.uniberg.com/marius.gerling/session-db-evaluator.git
-#    dest: /home/ubuntu/session-db-evaluator
-#    accept_hostkey: true

--- a/conf/roles/prometheus-node-exporter/files/node_exporter.service
+++ b/conf/roles/prometheus-node-exporter/files/node_exporter.service
@@ -1,0 +1,14 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
+Documentation=https://github.com/prometheus/node_exporter
+After=network.target
+
+[Service]
+User=prometheus
+ExecStart=/opt/node_exporter/node_exporter
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/roles/prometheus-node-exporter/tasks/main.yml
+++ b/conf/roles/prometheus-node-exporter/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Create Prometheus User
+  user:
+    name: prometheus
 - name: Extract Prometheus Node Exporter
   unarchive:
     src: /opt/repo/node_exporter-0.14.0.linux-amd64.tar.gz
@@ -9,5 +12,20 @@
     src: /opt/node_exporter-0.14.0.linux-amd64
     dest: /opt/node_exporter 
     state: link
-- name: Start Prometheus Node Exporter
-  shell: nohup /opt/node_exporter/node_exporter 2>&1 &
+- name: Set Owner and Permissions
+  file:
+    path: /opt/node_exporter-0.14.0.linux-amd64
+    owner: prometheus
+    group: prometheus
+    recurse: yes
+    state: directory
+- name: Create the service
+  copy:
+    src: ../files/node_exporter.service
+    dest: /usr/lib/systemd/system/node_exporter.service
+- name: Activate Service
+  systemd:
+    name: node_exporter
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/conf/roles/prometheus-pushgateway/files/pushgateway.service
+++ b/conf/roles/prometheus-pushgateway/files/pushgateway.service
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Prometheus Pushgateway
+Documentation=https://prometheus.io
+After=network.target
+
+[Service]
+User=prometheus
+WorkingDirectory=/opt/pushgateway
+ExecStart=/opt/pushgateway/pushgateway
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/roles/prometheus-pushgateway/tasks/main.yml
+++ b/conf/roles/prometheus-pushgateway/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create Prometheus User
+  user:
+    name: prometheus
+- name: Extract Prometheus Pushgateway
+  unarchive:
+    src: /opt/repo/pushgateway-0.4.0.linux-amd64.tar.gz
+    dest: /opt/
+- name: Create Link
+  file:
+    src: /opt/pushgateway-0.4.0.linux-amd64
+    dest: /opt/pushgateway
+    state: link
+- name: Set Owner and Permissions
+  file:
+    path: /opt/pushgateway-0.4.0.linux-amd64
+    owner: prometheus
+    group: prometheus
+    recurse: yes
+    state: directory
+- name: Create the service
+  copy:
+    src: ../files/pushgateway.service
+    dest: /usr/lib/systemd/system/pushgateway.service
+- name: Activate Service
+  systemd:
+    name: pushgateway
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/conf/roles/prometheus/files/prometheus.service
+++ b/conf/roles/prometheus/files/prometheus.service
@@ -1,0 +1,15 @@
+# -*- mode: conf -*-
+
+[Unit]
+Description=Prometheus Time-Series Database
+Documentation=https://prometheus.io
+After=network.target
+
+[Service]
+User=prometheus
+WorkingDirectory=/opt/prometheus
+ExecStart=/opt/prometheus/prometheus
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/roles/prometheus/tasks/main.yml
+++ b/conf/roles/prometheus/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Create Prometheus User
+  user:
+    name: prometheus
 - name: Extract Prometheus
   unarchive:
     src: /opt/repo/prometheus-1.7.1.linux-amd64.tar.gz
@@ -8,37 +11,24 @@
     src: /opt/prometheus-1.7.1.linux-amd64
     dest: /opt/prometheus 
     state: link
-- name: Extract Prometheus Pushgateway
-  unarchive:
-    src: /opt/repo/pushgateway-0.4.0.linux-amd64.tar.gz
-    dest: /opt/
-- name: Create Link
-  file:
-    src: /opt/pushgateway-0.4.0.linux-amd64
-    dest: /opt/pushgateway
-    state: link
 - name: Configure
   copy:
     src: ../files/prometheus.yml
     dest: /opt/prometheus/prometheus.yml
-- name: Grafana
-  unarchive:
-    src: /opt/repo/grafana-4.4.1.linux-x64.tar.gz
-    dest: /opt/
-- name: Create Link
+- name: Set Owner and Permissions
   file:
-    src: /opt/grafana-4.4.1
-    dest: /opt/grafana
-    state: link
-- name: Data Path
-  file:
-    path: /var/lib/grafana
+    path: /opt/prometheus-1.7.1.linux-amd64
+    owner: prometheus
+    group: prometheus
+    recurse: yes
     state: directory
-- name: Log Path
-  file:
-    path: /var/log/grafana
-    state: directory
-- name: Plugin Path
-  file:
-    path: /var/lib/grafana/plugins
-    state: directory
+- name: Create the service
+  copy:
+    src: ../files/prometheus.service
+    dest: /usr/lib/systemd/system/prometheus.service
+- name: Activate Service
+  systemd:
+    name: prometheus
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -4,12 +4,20 @@
   - role: common
     become: yes
     become_user: root
-- hosts: mgmt load
+- hosts: mgmt
   roles:
   - role: filerepo
     become: yes
     become_user: root
   - role: prometheus
+    become: yes
+    become_user: root
+  - role: grafana
+    become: yes
+    become_user: root
+- hosts: mgmt load
+  roles:
+  - role: prometheus-pushgateway
     become: yes
     become_user: root
 - hosts: all
@@ -23,9 +31,6 @@
     become: yes
     become_user: root
   - role: cassandra
-    become: yes
-    become_user: root
-  - role: riak
     become: yes
     become_user: root
   - role: couchbase


### PR DESCRIPTION
 - Use Systemd Services for
  - prometheus
  - node_exporter
  - pushgateway
  - grafana
 - Exclude grafana installation into a new role
 - Exclude pushgateway installation into a new role
 - Update site.yml to minimize the installation steps on load-servers